### PR TITLE
Configurable root output path, separate image output path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,8 @@ RUN mr_radar --help
 # Ensure we get the extended 256-color pallet when running with `-t`
 ENV TERM=xterm-256color
 
+# This allows the utility to detect if it's running in a Docker container
+ENV RLG_DOCKERIZED=True
+
 ENTRYPOINT [ "mr_radar" ]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -111,14 +111,20 @@ This is the four-letter site code (known as the ICAO) of the radar site from whi
 
 Here are the flags with explanations of each:
 
-| Flag                                | Default                                                         | Description                                                                                                                                                                             |
-|-------------------------------------|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| &#8209;&#8209;radius<br />&#8209;r  | 150                                                             | The distance in miles around the radar site that you'd like to cover in the generated images                                                                                            |
-| &#8209;&#8209;root<br />&#8209;R    | Dockerized:&nbsp;`/data`<br />Direct:&nbsp;`./out`              | The root path for all output (JSON cache file and generated images)                                                                                                                     |
-| &#8209;&#8209;images<br />&#8209;i  | `./<site_id>` relative to root path                             | The directory in which the generated PNG files will be saved, which will be relative to the root path.<br /><br />Specify an absolute path to save the images outside of the root path. |
-| &#8209;&#8209;file<br />&#8209;f    | Map mode:&nbsp;`map.png`<br />Frames mode:&nbsp;`frame_<i>.png` | The file name to use for the generated PNG file(s).<br />It is not necessary to include the `.png` extension.                                                                           |
-| &#8209;&#8209;frames<br />&#8209;n  | 12                                                              | The quantity of NEXRAD imagery frames to generate                                                                                                                                       |
-| &#8209;&#8209;product<br />&#8209;p | Reflectivity                                                    | The radar product to use for generating NEXRAD imagery frames.<br /><br />Hint: use the `dump-products` command to find the one you want.                                               |
+<!--
+    We'll need to use these to prevent the table from word-wrapping in the first two columns:
+        Non-breaking hyphen: &#8209;
+        Non-breaking space:  &#160; or &nbsp;
+-->
+
+| Flag                                | Default                                                                         | Description                                                                                                                                                                             |
+|-------------------------------------|---------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| &#8209;&#8209;radius<br />&#8209;r  | 150                                                                             | The distance in miles around the radar site that you'd like to feature in the generated images                                                                                          |
+| &#8209;&#8209;root<br />&#8209;R    | Dockerized:&nbsp;`/data`<br />Direct:&nbsp;`./out` in current working directory | The root path for all output (JSON cache file and generated images)                                                                                                                     |
+| &#8209;&#8209;images<br />&#8209;i  | `./<site_id>` relative to root path                                             | The directory in which the generated PNG files will be saved, which will be relative to the root path.<br /><br />Specify an absolute path to save the images outside of the root path. |
+| &#8209;&#8209;file<br />&#8209;f    | Map&nbsp;mode:&nbsp;`map.png`<br />Frames&nbsp;mode:&nbsp;`frame_<i>.png`       | The file name to use for the generated PNG file(s).<br />It is not necessary to include the `.png` extension.                                                                           |
+| &#8209;&#8209;frames<br />&#8209;n  | 12                                                                              | The quantity of NEXRAD imagery frames to generate                                                                                                                                       |
+| &#8209;&#8209;product<br />&#8209;p | Reflectivity                                                                    | The radar product to use for generating NEXRAD imagery frames.<br /><br />Hint: use the `dump-products` command to find the one you want.                                               |
 
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The easiest way to run this utility is with Docker, which guarantees that you wo
     docker build -t mr_radar:latest .
     ```
 
-2. Then run it:
+2. Then run it (minimal command to output `--help`):
     ```shell
     docker run -t --rm mr_radar:latest
     ```
@@ -104,20 +104,28 @@ Typically, the `map` command is only ever needed once; the only time you'd want 
 
 #### Site:
 
-This is the four-letter site code (known as the ICAO) of the WSR-88D radar site of which you want to use NEXRAD data.  Consult the [NWS Radar Operations Center](https://www.roc.noaa.gov/branches/program-branch/site-id-database.php) for various methods on finding available radar sites.
+This is the four-letter site code (known as the ICAO) of the radar site from which you want to use NEXRAD data.  Consult the [NWS Radar Operations Center](https://www.roc.noaa.gov/branches/program-branch/site-id-database.php) for various methods on finding available radar sites.
 
 
 ### Optional Arguments
 
 Here are the flags with explanations of each:
 
-| Flag              | Default                                               | Description                                                                                                                                         |
-|-------------------|-------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| --radius<br />-r  | 150                                                   | The distance in miles around the radar site that<br />you'd like to cover in the generated images                                                   |
-| --path<br />-P    | `./out`                                               | The path where generated PNG files will be saved                                                                                                    |
-| --file<br />-f    | Map mode: `map.png`<br />Frames mode: `frame_<i>.png` | The file name to use for the generated PNG file(s).<br />It is not necessary to include the `.png` extension.                                       |
-| --frames<br />-n  | 12                                                    | The quantity of NEXRAD imagery frames<br />(PNG files) to generate                                                                                  |
-| --product<br />-p | Reflectivity                                          | The radar product to use for generating NEXRAD<br />imagery frames.<br /><br />Hint: use the `dump-products` command to find<br />the one you want. |
+| Flag                                | Default                                                         | Description                                                                                                                                                                             |
+|-------------------------------------|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| &#8209;&#8209;radius<br />&#8209;r  | 150                                                             | The distance in miles around the radar site that you'd like to cover in the generated images                                                                                            |
+| &#8209;&#8209;root<br />&#8209;R    | Dockerized:&nbsp;`/data`<br />Direct:&nbsp;`./out`              | The root path for all output (JSON cache file and generated images)                                                                                                                     |
+| &#8209;&#8209;images<br />&#8209;i  | `./<site_id>` relative to root path                             | The directory in which the generated PNG files will be saved, which will be relative to the root path.<br /><br />Specify an absolute path to save the images outside of the root path. |
+| &#8209;&#8209;file<br />&#8209;f    | Map mode:&nbsp;`map.png`<br />Frames mode:&nbsp;`frame_<i>.png` | The file name to use for the generated PNG file(s).<br />It is not necessary to include the `.png` extension.                                                                           |
+| &#8209;&#8209;frames<br />&#8209;n  | 12                                                              | The quantity of NEXRAD imagery frames to generate                                                                                                                                       |
+| &#8209;&#8209;product<br />&#8209;p | Reflectivity                                                    | The radar product to use for generating NEXRAD imagery frames.<br /><br />Hint: use the `dump-products` command to find the one you want.                                               |
+
+
+> [!TIP]
+> When running in Docker, don't forget to map the `/data` directory within the container to a local path, or you won't get any of the generated images:
+> ```shell
+> docker run -t --rm --volume $(pwd)/out:/data mr_radar:latest <command> <site_id>
+> ```
 
 
 ### Example Usage
@@ -126,41 +134,38 @@ Generate a map with a 150-mile radius centered around KSJT:
 ```shell
 mr_radar map KSJT
 ```
-This will result in a new PNG file at `./out/map.png`. 
+This will result in a new PNG file at `./out/ksjt/map.png`. 
 
 Generate 12 of the latest NEXRAD frames for the same location and radius:
 ```shell
 mr_radar frames KSJT
 ```
-This will result in 12 new PNG files at `./out/frame_0.png` through `./out/frame_11.png`.
-
-
-> [!TIP]
-> When running in Docker, you'll need to override the output path with `--path`, and be sure to map the given path to a local path so that you actually get the images!
-> Example:
-> ```shell
-> docker run -t --rm --volume $(pwd)/out:/out mr_radar:latest --path /out <command> <site_id>
-> ```
+This will result in 12 new PNG files at `./out/ksjt/frame_0.png` through `./out/ksjt/frame_11.png`.
 
 
 ### Data Caching
 
-You will also find a new JSON file (`ksjt.json`, in this example) in your current working directory, which contains the command-line arguments you supplied, as well as additional derived information based on the site ID and radius.
+You will also find a new JSON file (`./out/ksjt.json`, in this example) in the root output path, which contains the command-line arguments you supplied, as well as additional derived information based on the site ID and radius.
 
 Here's what it's good for:
-1. This information makes subsequent runs faster and more efficient by re-using that information rather than having to make repeated requests for information that would never change (such as radar site coordinates, for instance).
-2. You will no longer need any of the optional command-line arguments on subsequent runs; those values will be read from this file if they are not present on the command line.  Simply run `python3 mr_radar frames <site_id>` to re-use the radius and frame count that you specified initially.
+1. This makes subsequent runs faster and more efficient by re-using information rather than having to make repeated requests for information that would never change (such as radar site coordinates, for instance).
+2. You will no longer need any of the optional command-line arguments on subsequent runs; those values will be read from this file if they are not present on the command line.
 
-Deleting this file won't hurt anything, but it's not necessary to do so with normal use.
+Deleting this file won't hurt anything, but it's not a necessary task in the course of normal use.
 
 
 ## Using in HTML
 
-Check out the [`html`](/../../tree/dev/html) directory for a basic example of how to "animate" the frames on top of the base map.  It will work out-of-the-box if you run the utility with the default output file path (`./out`) and names (`map.png` and `frame_<i>.png`).
+Check out the [`html`](./html) directory for a basic example of how to "animate" the frames on top of the base map.
 
-If you generate your map file and NEXRAD frames with non-default path and file names, you'll need to tweak the [`loop.html`](/../../tree/dev/html/loop.html) file to make it work.
+The example HTML will work out-of-the-box if you run the utility with:
+1. default root file path (`./out`)
+2. default file names (`map.png` and `frame_<i>.png`).
+3. specify `--images .` to save generated images in the root path
 
-Simply open `loop.html` in your browser (you can test drive it locally without using a web server).
+Otherwise, you'll need to tweak the [`loop.html`](./html/loop.html) file to make it work.
+
+To view the animated loop after generating the map and NEXRAD frames, simply open the `loop.html` file in your browser (no web server needed to test-drive locally).
 
 > [!IMPORTANT]
 > The example HTML files aren't intended to be deployed as-is to your website, they're just an example to show how to create an animated loop effect (but you may certainly copy/paste to your heart's desire).

--- a/mr_radar/cache_keys.py
+++ b/mr_radar/cache_keys.py
@@ -23,8 +23,12 @@ class CacheKeys:
         return 'envelope'
 
     @property
-    def FILE_PATH( self ) -> str:
-        return 'file_path'
+    def OUTPUT_PATH( self ) -> str:
+        return 'output_path'
+
+    @property
+    def IMAGE_PATH( self ) -> str:
+        return 'image_path'
 
     @property
     def FILE_NAME( self ) -> str | None:

--- a/mr_radar/cache_keys.py
+++ b/mr_radar/cache_keys.py
@@ -23,10 +23,6 @@ class CacheKeys:
         return 'envelope'
 
     @property
-    def OUTPUT_PATH( self ) -> str:
-        return 'output_path'
-
-    @property
     def IMAGE_PATH( self ) -> str:
         return 'image_path'
 

--- a/mr_radar/cli.py
+++ b/mr_radar/cli.py
@@ -15,7 +15,7 @@ def main():
 
     parser.add_argument(
         'command',
-        choices=[ 'map', 'frames', 'dump-products' ],
+        choices=[ 'map', 'frames', 'dump-products', 'dump-vars' ],
         help='The command to specify whether to generate the base map or NEXRAD radar imagery frames, or dump a list of available radar products for the given site'
     )
 
@@ -64,8 +64,13 @@ def main():
     generator = None
 
     try:
+        if command == 'dump-vars':
+            from .radar_loop_generator import RadarLoopGenerator
+            generator = RadarLoopGenerator( **args )
+            generator.dump( 'Dumping variables:', logger.debug )
+            generator = None
 
-        if command == 'map':
+        elif command == 'map':
             args.pop( 'frames' )
             args.pop( 'product' )
 

--- a/mr_radar/cli.py
+++ b/mr_radar/cli.py
@@ -39,14 +39,14 @@ def main():
 
     output_path_default = '/data' if is_dockerized() else './out'
     parser.add_argument(
-        '-D', '--root',
+        '-R', '--root',
         type=Path,
         dest='output_path',
         help=f'The root path for all output, including JSON cache file and images.  A non-absolute path will be relative to current working directory.  Default: {output_path_default}'
     )
 
     parser.add_argument(
-        '-o', '--output',
+        '-i', '--images',
         type=Path,
         dest='image_dir',
         help=f'The destination path for the generated images.  A non-absolute path will be relative to that specified by "--root".  Default: {output_path_default}/<SITE>'

--- a/mr_radar/cli.py
+++ b/mr_radar/cli.py
@@ -96,14 +96,16 @@ def main():
                 "\tRadius:      {radius}        \n"
                 "\tBBox:        {image_bbox}    \n"
                 "\tEnvelope:    {image_envelope}\n"
-                "\tFile Path:   {file_path_name}\n",
+                "\tOut Path:    {output_path}   \n"
+                "\tImage Path:  {image_path}    \n",
 
                 site_id        = generator.site_id,
                 site_coords    = generator.site_coords,
                 radius         = generator.radius,
                 image_bbox     = generator.image_bbox,
                 image_envelope = generator.image_envelope,
-                file_path_name = generator.file_path_name
+                output_path    = generator.output_path,
+                image_path     = generator.image_path
             )
 
         raise

--- a/mr_radar/cli.py
+++ b/mr_radar/cli.py
@@ -62,14 +62,14 @@ def main():
         '-n', '--frames',
         type=int,
         dest='frames',
-        help='The number of NEXRAD radar image frames to generate (default: 12)'
+        help='The number of NEXRAD radar image frames to generate. Default: 12'
     )
 
     parser.add_argument(
         '-p', '--product',
         type=str,
         dest='product',
-        help='The radar product to use for generating NEXRAD frames (default: Reflectivity)'
+        help='The radar product to use for generating NEXRAD frames.  Default: Reflectivity'
     )
 
     args = vars( parser.parse_args( args=None if sys.argv[2:] else ['--help'] ) )

--- a/mr_radar/cli.py
+++ b/mr_radar/cli.py
@@ -86,27 +86,9 @@ def main():
     except RLGException as e:
         logger.error( "Image generation aborted: {}", e )
 
-    except Exception as e:
+    except Exception:
         if generator:
-            logger.error(
-                "💥 KA-BOOM! 💥"
-                "\n"
-                "\tSite:        {site_id}       \n"
-                "\tSite Coords: {site_coords}   \n"
-                "\tRadius:      {radius}        \n"
-                "\tBBox:        {image_bbox}    \n"
-                "\tEnvelope:    {image_envelope}\n"
-                "\tOut Path:    {output_path}   \n"
-                "\tImage Path:  {image_path}    \n",
-
-                site_id        = generator.site_id,
-                site_coords    = generator.site_coords,
-                radius         = generator.radius,
-                image_bbox     = generator.image_bbox,
-                image_envelope = generator.image_envelope,
-                output_path    = generator.output_path,
-                image_path     = generator.image_path
-            )
+            generator.dump( '💥 KA-BOOM! 💥', logger.error )
 
         raise
 

--- a/mr_radar/cli.py
+++ b/mr_radar/cli.py
@@ -1,11 +1,16 @@
 ## -*- coding: utf-8 -*-
 
-import argparse
+import argparse, sys
 from pathlib import Path
+from os import environ
+
 from loguru import logger
 
-
 from .rlg_exception import *
+
+
+def is_dockerized():
+    return environ.get( 'RLG_DOCKERIZED', False )
 
 def main():
 
@@ -32,11 +37,19 @@ def main():
         help='The distance in miles around the radar site to map'
     )
 
+    output_path_default = '/data' if is_dockerized() else './out'
     parser.add_argument(
-        '-P', '--path',
+        '-D', '--root',
         type=Path,
-        dest='path',
-        help='The destination path to the generated images.  Defaults to "./out" in current working directory.'
+        dest='output_path',
+        help=f'The root path for all output, including JSON cache file and images.  A non-absolute path will be relative to current working directory.  Default: {output_path_default}'
+    )
+
+    parser.add_argument(
+        '-o', '--output',
+        type=Path,
+        dest='image_dir',
+        help=f'The destination path for the generated images.  A non-absolute path will be relative to that specified by "--root".  Default: {output_path_default}/<SITE>'
     )
 
     parser.add_argument(

--- a/mr_radar/cli.py
+++ b/mr_radar/cli.py
@@ -72,8 +72,8 @@ def main():
         help='The radar product to use for generating NEXRAD frames (default: Reflectivity)'
     )
 
-    args = vars( parser.parse_args() )
-    command = args.pop('command')
+    args = vars( parser.parse_args( args=None if sys.argv[2:] else ['--help'] ) )
+    command = args.pop( 'command' )
     generator = None
 
     try:

--- a/mr_radar/frame_generator.py
+++ b/mr_radar/frame_generator.py
@@ -11,6 +11,7 @@ from matplotlib.cm import ScalarMappable
 from metpy.plots import ctables
 from awips.dataaccess import IGridData, IDataRequest, DataAccessLayer
 
+from .rlg_defaults import RLGDefaults
 from .cache_keys import RadarCacheKeys
 from .radar_loop_generator import RadarLoopGenerator
 from .rlg_exception import *
@@ -32,7 +33,7 @@ class FrameGenerator( RadarLoopGenerator ):
         super().__init__( site_id, radius, path )
         self.product = product
         self.frames = frames
-        self.file_name = ( name or 'frame' )
+        self.file_name = ( name or RLGDefaults.frame_file_name )
 
 
     @property
@@ -47,7 +48,7 @@ class FrameGenerator( RadarLoopGenerator ):
 
     @property
     def product( self ) -> int:
-        return self.cache.get( RadarCacheKeys.PRODUCT, 'Reflectivity' )
+        return self.cache.get( RadarCacheKeys.PRODUCT, RLGDefaults.product )
 
 
     @product.setter
@@ -61,7 +62,7 @@ class FrameGenerator( RadarLoopGenerator ):
 
     @property
     def frames( self ) -> int:
-        return self.cache.get( RadarCacheKeys.FRAMES, 12 )
+        return self.cache.get( RadarCacheKeys.FRAMES, RLGDefaults.frames )
 
 
     @frames.setter
@@ -81,7 +82,7 @@ class FrameGenerator( RadarLoopGenerator ):
 
 
     def generate( self ) -> None:
-        logger.info( "→ Image frames will be saved as '{}'", self.file_path_name )
+        logger.info( "→ Image frames will be saved as '{}'", self.image_file_path_name )
         logger.info( 'Generating NEXRAD image frames...' )
 
         super().generate()
@@ -113,7 +114,7 @@ class FrameGenerator( RadarLoopGenerator ):
 
     def save_image( self, index: int, metadata: dict ) -> str:
 
-        file_path_name = self.file_path_name % index
+        file_path_name = self.image_file_path_name % index
 
         super().save_image( file=file_path_name, transparent=True, metadata=metadata )
 
@@ -210,7 +211,7 @@ class FrameGenerator( RadarLoopGenerator ):
 
     def _generate_legend( self ) -> None:
 
-        legend_file = self.file_path_name.replace( '%d', '%s' ) % 'legend'
+        legend_file = self.image_file_path_name.replace( '%d', '%s' ) % 'legend'
 
         if Path( legend_file ).exists():
             return
@@ -228,7 +229,7 @@ class FrameGenerator( RadarLoopGenerator ):
         file_name_pattern = self.file_name.replace( '%d', '[0-9]+' )
 
         frame_count = 0
-        for frame in Path( self.file_path ).glob( file_name_glob ):
+        for frame in Path( self.image_path ).glob( file_name_glob ):
             if re.match( file_name_pattern, frame.name ):
                 frame_count += 1
 
@@ -240,6 +241,6 @@ class FrameGenerator( RadarLoopGenerator ):
         start = self.frames
         stop = frame_count
         for i in range( start, stop ):
-            Path( self.file_path_name % i ).unlink()
+            Path( self.image_file_path_name % i ).unlink()
 
         logger.info( "→ Deleted {} extra frames", stop - start )

--- a/mr_radar/frame_generator.py
+++ b/mr_radar/frame_generator.py
@@ -29,8 +29,8 @@ PNG_METADATA = {
 
 class FrameGenerator( RadarLoopGenerator ):
 
-    def __init__( self, site_id: str, radius: int=None, path: str=None, name: str=None, product=None, frames: int=None ) -> None:
-        super().__init__( site_id, radius, path )
+    def __init__( self, name: str=None, product: str=None, frames: int=None, **kwargs ) -> None:
+        super().__init__( **kwargs )
         self.product = product
         self.frames = frames
         self.file_name = ( name or RLGDefaults.frame_file_name )

--- a/mr_radar/map_generator.py
+++ b/mr_radar/map_generator.py
@@ -27,8 +27,8 @@ STATE_BORDERS   = 'admin_1_states_provinces_lines'
 
 class MapGenerator( RadarLoopGenerator ):
 
-    def __init__( self, site_id: str, radius: int=None, path: str=None, name: str=None, **kwargs ) -> None:
-        super().__init__( site_id, radius, path )
+    def __init__( self, name: str=None, **kwargs ) -> None:
+        super().__init__( **kwargs )
         self.file_name = ( name or RLGDefaults.map_file_name )
 
 

--- a/mr_radar/map_generator.py
+++ b/mr_radar/map_generator.py
@@ -8,6 +8,7 @@ from awips.dataaccess import DataAccessLayer
 from matplotlib import pyplot
 from cartopy.feature import ShapelyFeature, NaturalEarthFeature
 
+from .rlg_defaults import RLGDefaults
 from .cache_keys import RadarCacheKeys
 from .radar_loop_generator import RadarLoopGenerator
 
@@ -28,7 +29,7 @@ class MapGenerator( RadarLoopGenerator ):
 
     def __init__( self, site_id: str, radius: int=None, path: str=None, name: str=None, **kwargs ) -> None:
         super().__init__( site_id, radius, path )
-        self.file_name = ( name or 'map' )
+        self.file_name = ( name or RLGDefaults.map_file_name )
 
 
     @property
@@ -42,7 +43,7 @@ class MapGenerator( RadarLoopGenerator ):
 
 
     def generate( self ) -> None:
-        logger.info( "→ Map file will be saved as '{}'", self.file_path_name )
+        logger.info( "→ Map file will be saved as '{}'", self.image_file_path_name )
         logger.info( 'Generating map...' )
 
         super().generate()

--- a/mr_radar/radar_loop_generator.py
+++ b/mr_radar/radar_loop_generator.py
@@ -32,9 +32,10 @@ class RadarLoopGenerator:
 
         DataAccessLayer.changeEDEXHost( EDEX_HOST )
 
-        self._site_id = None
-        self._axes    = None
-        self._figure  = None
+        self._site_id     = None
+        self._output_path = None
+        self._axes        = None
+        self._figure      = None
 
         self.cache = RLGCache()
 

--- a/mr_radar/radar_loop_generator.py
+++ b/mr_radar/radar_loop_generator.py
@@ -127,7 +127,9 @@ class RadarLoopGenerator:
 
     @property
     def output_path( self ) -> str:
-        return self.cache.get( RadarCacheKeys.OUTPUT_PATH, RLGDefaults.output_path )
+        if not self._output_path:
+            self._output_path = RLGDefaults.output_path
+        return self._output_path
 
 
     @output_path.setter
@@ -138,7 +140,7 @@ class RadarLoopGenerator:
 
         path = Path( path ).resolve()
         self._validate_file_path( path )
-        self.cache.set( RadarCacheKeys.OUTPUT_PATH, str( path ) )
+        self._output_path = str( path )
 
 
     @property

--- a/mr_radar/radar_loop_generator.py
+++ b/mr_radar/radar_loop_generator.py
@@ -53,8 +53,7 @@ class RadarLoopGenerator:
     def site_id( self, site_id: str ) -> None:
         self._validate_site_id( site_id )
         self._site_id = site_id.upper()
-        json_path = Path( self.output_path, self.site_id )
-        self.cache.load( str( json_path ) )
+        self.cache.load( str( self.json_path ) )
         logger.info( "→ Site ID is '{}'", self.site_id )
 
 
@@ -140,6 +139,11 @@ class RadarLoopGenerator:
         path = Path( path ).resolve()
         self._validate_file_path( path )
         self.cache.set( RadarCacheKeys.OUTPUT_PATH, str( path ) )
+
+
+    @property
+    def json_path( self ) -> str:
+        return '%s.json' % str( Path( self.output_path, self.site_id.lower() ) )
 
 
     @property

--- a/mr_radar/radar_loop_generator.py
+++ b/mr_radar/radar_loop_generator.py
@@ -194,6 +194,32 @@ class RadarLoopGenerator:
         self._figure = figure
 
 
+    def dump( self, message: str, _logger: logger ) -> None:
+
+        self._check_site_coords()
+        self._check_image_bounds()
+
+        _logger( message + "\n"
+            "\tSite:        {site_id}       \n"
+            "\tSite Coords: {site_coords}   \n"
+            "\tRadius:      {radius}        \n"
+            "\tBBox:        {image_bbox}    \n"
+            "\tEnvelope:    {image_envelope}\n"
+            "\tOutput Root: {output_path}   \n"
+            "\tJSON Path:   {json_path}     \n"
+            "\tImage Path:  {image_path}/   \n",
+
+            site_id        = self.site_id,
+            site_coords    = self.site_coords,
+            radius         = self.radius,
+            image_bbox     = self.image_bbox,
+            image_envelope = self.image_envelope,
+            output_path    = self.output_path,
+            json_path      = self.json_path,
+            image_path     = self.image_path
+        )
+
+
     def generate( self ) -> None:
 
         self._check_site_coords()

--- a/mr_radar/radar_loop_generator.py
+++ b/mr_radar/radar_loop_generator.py
@@ -28,7 +28,7 @@ EDEX_HOST = 'edex-cloud.unidata.ucar.edu'
 
 class RadarLoopGenerator:
 
-    def __init__( self, site_id: str, radius: int=None, out_path: str=None, img_path: str=None ) -> None:
+    def __init__( self, site_id: str, radius: int=None, output_path: str=None, image_dir: str=None, **kwargs ) -> None:
 
         DataAccessLayer.changeEDEXHost( EDEX_HOST )
 
@@ -41,8 +41,8 @@ class RadarLoopGenerator:
 
         self.site_id     = site_id
         self.radius      = radius
-        self.output_path = out_path
-        self.image_path  = img_path
+        self.output_path = output_path
+        self.image_path  = image_dir
 
 
     @property

--- a/mr_radar/radar_loop_generator.py
+++ b/mr_radar/radar_loop_generator.py
@@ -198,6 +198,10 @@ class RadarLoopGenerator:
 
         self._check_site_coords()
         self._check_image_bounds()
+
+        path = Path( self.output_path )
+        path.mkdir( parents=True, exist_ok=True )
+
         self.cache.dump()
 
 

--- a/mr_radar/radar_loop_generator.py
+++ b/mr_radar/radar_loop_generator.py
@@ -150,7 +150,11 @@ class RadarLoopGenerator:
 
     @property
     def image_path( self ) -> str:
-        return self.cache.get( RadarCacheKeys.IMAGE_PATH, self.site_id.lower() )
+        image_dir = self.cache.get( RadarCacheKeys.IMAGE_PATH, self.site_id.lower() )
+        image_path =  Path( image_dir )
+        if not image_path.is_absolute():
+            image_path = Path( self.output_path, image_path )
+        return str( image_path )
 
 
     @image_path.setter
@@ -166,10 +170,7 @@ class RadarLoopGenerator:
 
     @property
     def image_file_path_name( self ) -> str:
-        image_path = Path( self.image_path )
-        if not image_path.is_absolute():
-            image_path = Path( self.output_path, image_path )
-        image_file_path = Path( image_path, self.file_name )
+        image_file_path = Path( self.image_path, self.file_name )
         return str( image_file_path )
 
 
@@ -201,7 +202,7 @@ class RadarLoopGenerator:
 
 
     def save_image( self, **kwargs ) -> None:
-        path = Path( self.image_file_path_name ).parent
+        path = Path( self.image_path )
         path.mkdir( parents=True, exist_ok=True )
 
         figure = kwargs.pop( 'figure' ) if 'figure' in kwargs else self.figure

--- a/mr_radar/rlg_cache.py
+++ b/mr_radar/rlg_cache.py
@@ -33,7 +33,9 @@ class RLGCache:
         return path_exists and is_file
 
     def load( self, name ) -> None:
-        self._json_file = f"{name.lower()}.json"
+        if name[-5:].lower() != '.json':
+            name += '.json'
+        self._json_file = name
         self._pickledb = pickledb.load( self._json_file, False )
 
     def get( self, key, default=None ) -> Any | None:

--- a/mr_radar/rlg_cache.py
+++ b/mr_radar/rlg_cache.py
@@ -66,3 +66,4 @@ class RLGCache:
             return self._pickledb.dump()
 
         return True
+

--- a/mr_radar/rlg_cache.py
+++ b/mr_radar/rlg_cache.py
@@ -19,7 +19,7 @@ class RLGCache:
         self._dirty = False
         self._json_file = None
 
-    def __contains__( self, key ) -> bool:
+    def __contains__( self, key: str ) -> bool:
         return self._pickledb.exists( key )
 
     @property
@@ -32,13 +32,13 @@ class RLGCache:
         is_file = Path( self._json_file ).is_file()
         return path_exists and is_file
 
-    def load( self, name ) -> None:
+    def load( self, name: str ) -> None:
         if name[-5:].lower() != '.json':
             name += '.json'
         self._json_file = name
         self._pickledb = pickledb.load( self._json_file, False )
 
-    def get( self, key, default=None ) -> Any | None:
+    def get( self, key: str, default=None ) -> Any | None:
         if not self._pickledb.exists( key ):
             self._pickledb.set( key, default )
         return self._pickledb.get( key )
@@ -54,11 +54,11 @@ class RLGCache:
 
         return False
 
-    def rem( self, key ) -> bool:
+    def rem( self, key: str ) -> bool:
         self._dirty = True
         return self._pickledb.rem( key )
 
-    def dump( self, force=False ) -> bool:
+    def dump( self, force: bool=False ) -> bool:
 
         if not self._json_file:
             return False

--- a/mr_radar/rlg_defaults.py
+++ b/mr_radar/rlg_defaults.py
@@ -1,0 +1,43 @@
+## -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+from os import environ
+from pathlib import Path
+
+class _RLGDefaults:
+
+    def __init__( self ):
+        self._dockerized = environ.get( 'RLG_DOCKERIZED', False )
+
+    @property
+    def output_path( self ) -> str:
+        cwd_out = str( Path( Path.cwd(), 'out' ) )
+        return '/data' if self.dockerized else cwd_out
+
+    @property
+    def map_file_name( self ) -> str:
+        return 'map'
+
+    @property
+    def frame_file_name( self ) -> str:
+        return 'frame'
+
+    @property
+    def radius( self ) -> int:
+        return 150
+
+    @property
+    def product( self ) -> str:
+        return 'Reflectivity'
+
+    @property
+    def frames( self ) -> int:
+        return 12
+
+    @property
+    def dockerized( self ):
+        return self._dockerized
+
+
+RLGDefaults = _RLGDefaults()

--- a/mr_radar/rlg_defaults.py
+++ b/mr_radar/rlg_defaults.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from os import environ
-from pathlib import Path
+
 
 class _RLGDefaults:
 
@@ -12,8 +12,7 @@ class _RLGDefaults:
 
     @property
     def output_path( self ) -> str:
-        cwd_out = str( Path( Path.cwd(), 'out' ) )
-        return '/data' if self.dockerized else cwd_out
+        return '/data' if self.dockerized else './out'
 
     @property
     def map_file_name( self ) -> str:


### PR DESCRIPTION
This PR addresses the proposed solutions in Issue #16.

There is now an option to specify a root output path, which is where the cache JSON file will be saved.  The default image output path (or a provided directory/path name) will be relative to the root output path.  The image output path can be located outside of the root path by providing an absolute path.

Other tweaks were applied along the way.